### PR TITLE
Bugfix: strings should not be quoted in sql statements

### DIFF
--- a/app/persistence/postgresql/PostgresqlRepository.scala
+++ b/app/persistence/postgresql/PostgresqlRepository.scala
@@ -297,7 +297,7 @@ class PostgresqlRepository @Inject() (
 
   def extractIdString(json: JsObject): String =
     (json \ "id").getOrElse(JsNull) match {
-      case JsString(v) => s"'$v'"
+      case JsString(v) => v
       case JsNumber(i) => i.toString()
       case _ => throw new IllegalArgumentException("No ID property of type String or Number")
     }

--- a/test/integration/TransactionAPISpec.scala
+++ b/test/integration/TransactionAPISpec.scala
@@ -30,7 +30,7 @@ class TransactionAPISpec extends InCollectionSpecification {
         return OK when the collection exists, and data is valid                   $e5
         metadata query returns the inserted number of objects                     $e6
 
-     The transaction /bulkupsert should:
+     The transaction /upsert should:
         return OK when the collection exists, and data is valid                   $e5u
 
       The transaction /delete should:


### PR DESCRIPTION
variables are not inserted in the query string but binded in slick sqlu
this resulted in single quotes around text keys in de database
upserts in existing datasets resulted in double entries:
the existing entry with non-quoted key and the new with a quoted 'key'