### PR TITLE
Fix distinct for regular tables: removes "properties." prefix

### DIFF
--- a/app/persistence/postgresql/PGRegularQueryRenderer.scala
+++ b/app/persistence/postgresql/PGRegularQueryRenderer.scala
@@ -7,8 +7,15 @@ import persistence.querylang._
  */
 object PGRegularQueryRenderer extends BaseQueryRenderer {
 
-  override def renderPropertyExpr(expr: PropertyExpr): String = if (expr.path.trim.startsWith("properties.")) expr.path.trim.substring(11)
-  else expr.path
+  override def renderPropertyExpr(expr: PropertyExpr): String = {
+    val withoutPrefix =
+      if (expr.path.trim.startsWith("properties.")) {
+        expr.path.trim.substring(11)
+      } else {
+        expr.path
+      }
+    s""""$withoutPrefix""""
+  }
 
   override def cast(exp: Expr): String = "" // don't cast
 

--- a/test/persistence/postgresql/PGQueryRenderSpec.scala
+++ b/test/persistence/postgresql/PGQueryRenderSpec.scala
@@ -3,8 +3,6 @@ package persistence.postgresql
 import org.specs2.mutable.Specification
 import persistence.querylang.{ QueryParser, BooleanExpr }
 
-import scala.util.Try
-
 /**
  * Created by Karel Maesen, Geovise BVBA on 23/01/15.
  */
@@ -131,50 +129,50 @@ class PGQueryRenderSpec extends Specification {
     val renderer = PGRegularQueryRenderer
 
     "properly render boolean expressions containing equality expresssions " in {
-      val expr: BooleanExpr = QueryParser.parse("ab.cd = 12").get
-      compressWS(renderer.render(expr)) === "ab.cd = ( 12 )"
+      val expr: BooleanExpr = QueryParser.parse("abcd = 12").get
+      compressWS(renderer.render(expr)) === """"abcd" = ( 12 )"""
     }
 
     "properly render comparison expressions contain boolean literal" in {
-      val expr = QueryParser.parse("ab.cd = TRUE").get
-      compressWS(renderer.render(expr)) === "ab.cd = ( true )"
+      val expr = QueryParser.parse("abcd = TRUE").get
+      compressWS(renderer.render(expr)) === """"abcd" = ( true )"""
     }
 
     "properly render simple equality expression " in {
       val expr = QueryParser.parse("properties.foo = 'bar1'").get
-      compressWS(renderer.render(expr)) === "foo = ( 'bar1' )"
+      compressWS(renderer.render(expr)) === """"foo" = ( 'bar1' )"""
     }
 
     "properly render boolean expressions containing comparison expresssions other than equality " in {
 
-      val expr1 = QueryParser.parse("ab.cd > 12").get
-      val expr2 = QueryParser.parse("ab.cd >= 12").get
-      val expr3 = QueryParser.parse("ab.cd != 'abc'").get
+      val expr1 = QueryParser.parse("abcd > 12").get
+      val expr2 = QueryParser.parse("abcd >= 12").get
+      val expr3 = QueryParser.parse("abcd != 'abc'").get
 
       (
-        compressWS(renderer.render(expr1)) === "ab.cd > ( 12 )"
-      ) and (
-          compressWS(renderer.render(expr2)) === "ab.cd >= ( 12 )"
+        compressWS(renderer.render(expr1)) === """"abcd" > ( 12 )"""
         ) and (
-            compressWS(renderer.render(expr3)) === "ab.cd != ( 'abc' )"
-          )
+        compressWS(renderer.render(expr2)) === """"abcd" >= ( 12 )"""
+        ) and (
+        compressWS(renderer.render(expr3)) === """"abcd" != ( 'abc' )"""
+        )
     }
 
     "properly render negated expressions " in {
-      val expr1 = QueryParser.parse("not ab.cd = 12").get
-      compressWS(renderer.render(expr1)) === "NOT ( ab.cd = ( 12 ) )"
+      val expr1 = QueryParser.parse("not abcd = 12").get
+      compressWS(renderer.render(expr1)) === """NOT ( "abcd" = ( 12 ) )"""
     }
 
     "properly render AND expressions " in {
       val expr1 = QueryParser.parse(" (ab = 12) and (cd > 'c') ").get
       compressWS(renderer.render(expr1)) ===
-        "( ab = ( 12 ) ) AND ( cd > ( 'c' ) )"
+        """( "ab" = ( 12 ) ) AND ( "cd" > ( 'c' ) )"""
     }
 
     "properly render OR expressions " in {
       val expr1 = QueryParser.parse(" (ab = 12) or (cd > 'c') ").get
       compressWS(renderer.render(expr1)) ===
-        "( ab = ( 12 ) ) OR ( cd > ( 'c' ) )"
+        """( "ab" = ( 12 ) ) OR ( "cd" > ( 'c' ) )"""
     }
 
     "properly render a boolean literal as a boolean expression" in {
@@ -183,59 +181,59 @@ class PGQueryRenderSpec extends Specification {
     }
 
     "property render an IN predicate expression" in {
-      val expr1 = QueryParser.parse(" a.b in (1,2,3) ").get
+      val expr1 = QueryParser.parse(" ab in (1,2,3) ").get
       compressWS(renderer.render(expr1)) ===
-        "a.b in (3,2,1)"
+        """"ab" in (3,2,1)"""
     }
 
     "properly render simple regex expression " in {
       val expr = QueryParser.parse("properties.foo ~ /bar1.*/").get
-      compressWS(renderer.render(expr)) === "foo ~ 'bar1.*'"
+      compressWS(renderer.render(expr)) === """"foo" ~ 'bar1.*'"""
     }
 
     "properly render simple like expression " in {
       val expr = QueryParser.parse("properties.foo like 'a%bcd'").get
-      compressWS(renderer.render(expr)) === "foo like 'a%bcd'"
+      compressWS(renderer.render(expr)) === """"foo" like 'a%bcd'"""
     }
 
     "properly render simple ilike expression " in {
       val expr = QueryParser.parse("properties.foo ilike 'a%bcd'").get
-      compressWS(renderer.render(expr)) === "foo ilike 'a%bcd'"
+      compressWS(renderer.render(expr)) === """"foo" ilike 'a%bcd'"""
     }
 
     "properly render IS NULL expression " in {
       val expr = QueryParser.parse("properties.foo is null").get
-      compressWS(renderer.render(expr)) === "foo is null"
+      compressWS(renderer.render(expr)) === """"foo" is null"""
     }
 
     "properly render IS NOT NULL expression " in {
       val expr = QueryParser.parse("properties.foo is not null").get
-      compressWS(renderer.render(expr)) === "foo is not null"
+      compressWS(renderer.render(expr)) === """"foo" is not null"""
     }
 
     "properly render Intersects bbox  expression" in {
       val expr = QueryParser.parse("intersects bbox").get
-      compressWS(renderer.render(expr)) === "ST_Intersects( geometry, 'SRID=31370;POLYGON((1 1,100 1,100 100,1 100,1 1))' )"
+      compressWS(renderer.render(expr)) === """ST_Intersects( geometry, 'SRID=31370;POLYGON((1 1,100 1,100 100,1 100,1 1))' )"""
     }
 
     "properly render Intersects with Wkt Literal  expression" in {
       val expr = QueryParser.parse("intersects 'SRID=31370;POINT(10 12)'").get
-      compressWS(renderer.render(expr)) === "ST_Intersects( geometry, 'SRID=31370;POINT(10 12)' )"
+      compressWS(renderer.render(expr)) === """ST_Intersects( geometry, 'SRID=31370;POINT(10 12)' )"""
     }
 
     "properly render JsonContains expression" in {
       val expr = QueryParser.parse(""" properties.test @> '["a", 2]' """).get
-      compressWS(renderer.render(expr)) === """test::jsonb @> '["a", 2]'::jsonb"""
+      compressWS(renderer.render(expr)) === """"test"::jsonb @> '["a", 2]'::jsonb"""
     }
 
     "properly render to_date functions in expression" in {
       val expr = QueryParser.parse(" to_date( foo, 'YYYY-MM-DD') = to_date('2019-04-30', 'YYYY-MM-DD') ").get
-      compressWS(renderer.render(expr)) === """to_date(foo, 'YYYY-MM-DD' ) = ( to_date( '2019-04-30' , 'YYYY-MM-DD' ) )"""
+      compressWS(renderer.render(expr)) === """to_date("foo", 'YYYY-MM-DD' ) = ( to_date( '2019-04-30' , 'YYYY-MM-DD' ) )"""
     }
 
     "properly render between .. and operator in expression" in {
       val expr = QueryParser.parse(" to_date( foo, 'YYYY-MM-DD') between '2011-01-01' and '2012-01-01' ").get
-      compressWS(renderer.render(expr)) === """( to_date(foo, 'YYYY-MM-DD' ) between '2011-01-01' and '2012-01-01' )"""
+      compressWS(renderer.render(expr)) === """( to_date("foo", 'YYYY-MM-DD' ) between '2011-01-01' and '2012-01-01' )"""
     }
 
   }


### PR DESCRIPTION
Also using existing code to render part of the distinct query:

`PGJsonQueryRenderer.propertyPathAsJsonText(propertyExpr)`

and 

`PGRegularQueryRenderer.renderPropertyExpr(propertyExpr)`
