### PR TITLE
Play 3.0.9 + Pekko (implicit 1.0.3)

### DIFF
--- a/app/config/AppExecutionContexts.scala
+++ b/app/config/AppExecutionContexts.scala
@@ -1,6 +1,5 @@
 package config
 
-import play.api.libs.concurrent.Akka
 import scala.concurrent.ExecutionContext
 
 /**

--- a/app/controllers/MetricsController.scala
+++ b/app/controllers/MetricsController.scala
@@ -18,7 +18,7 @@ class MetricsController @Inject() (val repository: Repository) extends InjectedC
   val textContentType = "text/plain; version=0.0.4"
   val protoBufContentType = "application/vnd.google.protobuf; proto=io.prometheus.client.MetricFamily; encoding=delimited"
 
-  implicit val timeout: akka.util.Timeout = 5.seconds
+  implicit val timeout: org.apache.pekko.util.Timeout = 5.seconds
 
   def get = Action { implicit req =>
     val prometheusMetrics = getPrometheusSamples

--- a/app/controllers/QueryController.scala
+++ b/app/controllers/QueryController.scala
@@ -2,8 +2,8 @@ package controllers
 
 import javax.inject.Inject
 import Exceptions._
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Source
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.Source
 import config.AppExecutionContexts
 import metrics.{ Instrumentation, Operation }
 import org.geolatte.geom.Envelope

--- a/app/controllers/Resource.scala
+++ b/app/controllers/Resource.scala
@@ -4,8 +4,8 @@ import java.sql.Timestamp
 import java.time.OffsetDateTime
 import java.time.format.DateTimeFormatter
 import Exceptions.{ QueryTimeoutException, UnsupportedMediaException }
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
+import org.apache.pekko.stream.scaladsl.Source
+import org.apache.pekko.util.ByteString
 import config.Constants
 import org.geolatte.geom.{ Envelope, Geometry, Point }
 import org.supercsv.encoder.DefaultCsvEncoder

--- a/app/controllers/TxController.scala
+++ b/app/controllers/TxController.scala
@@ -2,7 +2,7 @@ package controllers
 
 import javax.inject.Inject
 import Exceptions._
-import akka.stream.scaladsl.{ JsonFraming, Keep, Sink }
+import org.apache.pekko.stream.scaladsl.{ JsonFraming, Keep, Sink }
 import config.AppExecutionContexts
 import metrics.Instrumentation
 import persistence.querylang.{ BooleanExpr, QueryParser }

--- a/app/filters/Filters.scala
+++ b/app/filters/Filters.scala
@@ -5,7 +5,7 @@ import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import javax.inject.Inject
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import metrics.Metrics
 import net.logstash.logback.marker.LogstashMarker
 import net.logstash.logback.marker.Markers.appendEntries

--- a/app/persistence/Repository.scala
+++ b/app/persistence/Repository.scala
@@ -2,7 +2,7 @@ package persistence
 
 import java.sql.Timestamp
 
-import akka.stream.scaladsl.Source
+import org.apache.pekko.stream.scaladsl.Source
 import controllers.{ IndexDef, IndexDefW }
 import org.geolatte.geom.Envelope
 import persistence.GeoJsonFormats._

--- a/app/persistence/postgresql/PostgresqlRepository.scala
+++ b/app/persistence/postgresql/PostgresqlRepository.scala
@@ -1,9 +1,9 @@
 package persistence.postgresql
 
 import Exceptions._
-import akka.stream._
-import akka.stream.scaladsl._
-import akka.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
+import org.apache.pekko.stream._
+import org.apache.pekko.stream.scaladsl._
+import org.apache.pekko.stream.stage.{ GraphStage, GraphStageLogic, InHandler, OutHandler }
 import config.AppExecutionContexts
 import controllers.{ Formats, IndexDef, IndexDefW }
 import metrics.Metrics

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-scalaVersion := "2.13.13"
+scalaVersion := "2.13.16"
 
 val appName = "geolatte-featureserver"
 val appVersion = "2.0-SNAPSHOT"
@@ -21,8 +21,8 @@ lazy val coreDependencies = Seq(
 //  "commons-codec" % "commons-codec" % "1.8",
   "net.sf.supercsv" % "super-csv" % "2.4.0",
   "org.parboiled" %% "parboiled" % "2.5.1",
-  "com.typesafe.akka" %% "akka-slf4j" % "2.6.21",
-  "net.logstash.logback" % "logstash-logback-encoder" % "6.2",
+  "org.apache.pekko" %% "pekko-slf4j" % play.core.PlayVersion.pekkoVersion,
+  "net.logstash.logback" % "logstash-logback-encoder" % "7.3",
   filters,
   guice
   )
@@ -32,7 +32,7 @@ lazy val slickVersion = "3.3.2"
 lazy val psqlDependencies = Seq(
   "com.typesafe.slick" %% "slick" % slickVersion,
   "com.typesafe.slick" %% "slick-hikaricp" % slickVersion,
-  "org.postgresql" % "postgresql" % "42.7.2"
+  "org.postgresql" % "postgresql" % "42.7.8"
   )
 
 lazy val prometheusClientVersion = "0.8.0"
@@ -86,11 +86,13 @@ val testSettings = Seq(
   ItTest / testOptions := Seq( Tests.Argument( "sequential" ), Tests.Filter( itFilter ) )
   )
 
-val `geolatte-geoserver` = (project in file("."))
+val `geolatte-geoserver` = project
+  .in(file("."))
   .settings(
-    defaultSettings *
-    ).configs( ItTest )
+    defaultSettings:_*
+  )
+  .configs( ItTest )
   .settings( inConfig( ItTest )( Defaults.testTasks ): _* )
-  .settings( (defaultSettings ++ testSettings) * )
+  .settings( defaultSettings ++ testSettings:_* )
   //    .settings(routesGenerator := InjectedRoutesGenerator)
   .enablePlugins(PlayScala)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -49,14 +49,14 @@ fs.postgresql {
 
 
 
-# Akka config
+# Pekko config
 play {
 
   modules.enabled += "modules.RepoModule"
   modules.enabled += "modules.MetricsModule"
 
-  akka {
-    loggers = [akka.event.slf4j.Slf4jLogger]
+  pekko {
+    loggers = [org.apache.pekko.event.slf4j.Slf4jLogger]
     loglevel = INFO
     actor {
       default-dispatcher = {

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.11.6

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,4 +2,5 @@
 logLevel := Level.Warn
 
 // Use the Play sbt plugin for Play project
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.9.1")
+addSbtPlugin("org.playframework" % "sbt-plugin"              % "3.0.9")
+addSbtPlugin("nl.gn0s1s"         % "sbt-pekko-version-check" % "0.0.8")

--- a/test/integration/FeatureServerSpecification.scala
+++ b/test/integration/FeatureServerSpecification.scala
@@ -1,6 +1,6 @@
 package integration
 
-import akka.stream.Materializer
+import org.apache.pekko.stream.Materializer
 import org.specs2._
 import org.specs2.matcher.{ Expectable, Matcher }
 import org.specs2.specification.core.{ Env, Fragments, SpecStructure }

--- a/test/integration/RestApi.scala
+++ b/test/integration/RestApi.scala
@@ -1,9 +1,9 @@
 package integration
 
-import akka.actor.ActorSystem
-import akka.stream.scaladsl.Sink
-import akka.stream.{ ActorMaterializer, Materializer }
-import akka.util.{ ByteString, Timeout }
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.stream.scaladsl.Sink
+import org.apache.pekko.stream.{ ActorMaterializer, Materializer }
+import org.apache.pekko.util.{ ByteString, Timeout }
 import config.Constants
 import controllers.SupportedMediaTypes
 import org.geolatte.geom._

--- a/test/integration/TransactionAPISpec.scala
+++ b/test/integration/TransactionAPISpec.scala
@@ -1,6 +1,6 @@
 package integration
 
-import akka.util.ByteString
+import org.apache.pekko.util.ByteString
 import config.Constants
 import persistence.json.Gen
 import org.specs2.matcher.MatchResult

--- a/test/integration/ViewDefsAPISpec.scala
+++ b/test/integration/ViewDefsAPISpec.scala
@@ -6,7 +6,7 @@ import play.api.libs.json._
 import play.api.http.Status._
 import org.geolatte.geom.Envelope
 import play.api.test.Helpers
-import akka.util.Timeout
+import org.apache.pekko.util.Timeout
 
 /**
  * @author Karel Maesen, Geovise BVBA


### PR DESCRIPTION
Upgrade to Play 3.0.9 (with its dependent Pekko 1.0.3)

Other upgrades:
- sbt 1.11.6
- scalaVersion 2.13.16
- logstash-logback-encoder 7.3
- postgresql 42.7.8